### PR TITLE
fix #6.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,4 +5,4 @@ sed -i "s/@SESSION_SECRET@/$SECRET/g" config/web.json
 sed -i "s/@JUDGE_TOKEN@/$SECRET/g" config/web.json
 sed -i "s/@JUDGE_TOKEN@/$SECRET/g" config/daemon.json
 sed -i "s/@EMAIL_JWT_SECRET@/$SECRET/g" config/web.json
-docker run -i --rm --network syzoj-docker_net mariadb:10.3 mysql -uroot -p123456 -hmysql < init.sql
+docker run -i --rm --network syzoj_net mariadb:10.3 mysql -uroot -p123456 -hmysql < init.sql


### PR DESCRIPTION
（不会说英语见谅。

在 `sh install.sh` 一步时遇到了和 #6 相同的问题

```shell
# memset0 @ macbook in ~/Project/syzoj on git:master 
$ bash install.sh
tr: Illegal byte sequence
sed: 1: "config/web.json": command c expects \ followed by text
sed: 1: "config/web.json": command c expects \ followed by text
sed: 1: "config/daemon.json": command c expects \ followed by text
sed: 1: "config/web.json": command c expects \ followed by text
docker: Error response from daemon: network syzoj-docker_net not found.
```

运行 `docker network ls` 发现没有名为 `syzoj-docker_net` 的 network。

```shell
# memset0 @ macbook in ~/Project/syzoj on git:master
$ docker network ls                
NETWORK ID          NAME                DRIVER              SCOPE
b436c64b2d1d        bridge              bridge              local
cf35079cb27b        host                host                local
72a1ba85b4f9        none                null                local
43c9a4cffbab        syzoj_net           bridge              local
```

故尝试将 `install.sh` 中的 `syzoj-docker_net` 改成 `syzoj_net`，发现可以运行。

系统 MacOS 10.14，docker 相关信息如下：

```shell
# memset0 @ macbook in ~/Project/syzoj on git:master
$ docker version   
Client: Docker Engine - Community
 Version:           19.03.5
 API version:       1.40
 Go version:        go1.12.12
 Git commit:        633a0ea
 Built:             Wed Nov 13 07:22:34 2019
 OS/Arch:           darwin/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.5
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.12
  Git commit:       633a0ea
  Built:            Wed Nov 13 07:29:19 2019
  OS/Arch:          linux/amd64
  Experimental:     true
 containerd:
  Version:          v1.2.10
  GitCommit:        b34a5c8af56e510852c35414db4c1f4fa6172339
 runc:
  Version:          1.0.0-rc8+dev
  GitCommit:        3e425f80a8c931f88e6d94a8c831b9d5aa481657
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683

# memset0 @ macbook in ~/Project/syzoj on git:master
$ docker info                 
Client:
 Debug Mode: false

Server:
 Containers: 6
  Running: 5
  Paused: 0
  Stopped: 1
 Images: 6
 Server Version: 19.03.5
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Native Overlay Diff: true
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: b34a5c8af56e510852c35414db4c1f4fa6172339
 runc version: 3e425f80a8c931f88e6d94a8c831b9d5aa481657
 init version: fec3683
 Security Options:
  seccomp
   Profile: default
 Kernel Version: 4.19.76-linuxkit
 Operating System: Docker Desktop
 OSType: linux
 Architecture: x86_64
 CPUs: 6
 Total Memory: 1.943GiB
 Name: docker-desktop
 ID: P3S2:HGJE:6LUK:J3OK:OAOW:TTQS:VIW3:A7PX:IKCX:G44X:M56H:C7GQ
 Docker Root Dir: /var/lib/docker
 Debug Mode: true
  File Descriptors: 76
  Goroutines: 83
  System Time: 2020-02-06T05:31:09.609370021Z
  EventsListeners: 3
 HTTP Proxy: gateway.docker.internal:3128
 HTTPS Proxy: gateway.docker.internal:3129
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: true
 Insecure Registries:
  127.0.0.0/8
 Registry Mirrors:
  http://hub-mirror.c.163.com/
 Live Restore Enabled: false
 Product License: Community Engine
```

在项目里搜索了一下没找到 `syzoj_net` 关键词相关信息（没有任何 docker 基础请见谅

因此不知道是为什么也不知道对不对

先 pr 一下，bzd 在其他的环境下是怎么样的。
